### PR TITLE
Game/average goals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5264,7 +5264,7 @@ Style/SymbolLiteral:
 
 Style/SymbolProc:
   Description: 'Use symbols as procs instead of blocks when possible.'
-  Enabled: false
+  Enabled: true
   Safe: false
   VersionAdded: '0.26'
   VersionChanged: '1.40'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5264,7 +5264,7 @@ Style/SymbolLiteral:
 
 Style/SymbolProc:
   Description: 'Use symbols as procs instead of blocks when possible.'
-  Enabled: true
+  Enabled: false
   Safe: false
   VersionAdded: '0.26'
   VersionChanged: '1.40'

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -35,7 +35,6 @@ class StatTracker
     (home_wins.count / number_of_games).round(2)
   end
 
-
   def percentage_visitor_wins
     number_of_games = @games.count.to_f
     visitor_wins = @games.find_all do |game|
@@ -52,6 +51,12 @@ class StatTracker
     (tie_games.count / number_of_games).round(2)
   end
 
+  def count_of_games_by_season
+    count_of_games = Hash.new(0)
+    season_count = @games.map { |game| game.season }
+    season_count.each { |season| count_of_games[season] += 1 }
+    count_of_games
+  end
   ### LEAGUE STATS ###
   ### TEAM STATS ###
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -57,6 +57,14 @@ class StatTracker
     season_count.each { |season| count_of_games[season] += 1 }
     count_of_games
   end
+
+  def average_goals_per_game
+    number_of_games = @games.count.to_f
+    average_goals = @games.map do |game|
+      game.away_goals + game.home_goals
+    end
+    (average_goals.sum.to_f / number_of_games).round(2)
+  end
   ### LEAGUE STATS ###
   ### TEAM STATS ###
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -65,6 +65,19 @@ class StatTracker
     end
     (average_goals.sum.to_f / number_of_games).round(2)
   end
+
+  def average_goals_by_season
+    season_total_goals = Hash.new(0)
+    @games.each do |game|
+      season_total_goals[game.season] += game.away_goals + game.home_goals
+    end
+    season_average_goals = Hash.new(0)
+    season_total_goals.each do |season, _|
+      season_average_goals[season] = (season_total_goals[season].to_f / count_of_games_by_season[season]).round(2)
+    end
+    season_average_goals
+  end
+
   ### LEAGUE STATS ###
   ### TEAM STATS ###
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -57,4 +57,10 @@ RSpec.describe StatTracker do
         })
     end
   end
+
+  describe "#average_goals_per_game" do
+    it "can average the goals scored in a game across all seasons" do
+      expect(@stat_tracker.average_goals_per_game).to eq(4.22)
+    end
+  end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -44,4 +44,17 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.percentage_ties).to eq(0.2)
     end
   end
+
+  describe "#count_of_games_by_season" do
+    it "can count total number of games by season" do
+      expect(@stat_tracker.count_of_games_by_season).to eq({
+        "20122013" => 806,
+        "20162017" => 1317,
+        "20142015" => 1319,
+        "20152016" => 1321,
+        "20132014" => 1323,
+        "20172018" => 1355
+        })
+    end
+  end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -63,4 +63,18 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.average_goals_per_game).to eq(4.22)
     end
   end
+
+  describe "#average_goals_by_season" do
+    it "returns hash of average goals by season" do
+      expected = {
+      "20122013"=>4.12,
+      "20162017"=>4.23,
+      "20142015"=>4.14,
+      "20152016"=>4.16,
+      "20132014"=>4.19,
+      "20172018"=>4.44
+    }
+      expect(@stat_tracker.average_goals_by_season).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
This PR merges game/average_goals branch with the main. It includes the average_goals_by_season method with it's tests.
I ran spec harnes, rubocop and it has 100% coverage with simplecov.

```
Offenses:

lib/stat_tracker.rb:6:1: C: Metrics/ClassLength: Class has too many lines. [226/100]
class StatTracker ...
^^^^^^^^^^^^^^^^^
lib/stat_tracker.rb:81:3: C: Metrics/AbcSize: Assignment Branch Condition size for average_goals_by_season is too high. [<7, 16, 2> 17.58/17]
  def average_goals_by_season ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
Rubo cop errors unfixed^^